### PR TITLE
[fixes #31359335] Implemente navigation action(+pagination)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     slop (3.3.2)
     spoon (0.0.1)
     sqlite3 (1.3.6)
+    state_machine (1.1.2)
     systemu (2.5.2)
     thor (0.15.2)
     tilt (1.3.3)
@@ -147,5 +148,6 @@ DEPENDENCIES
   shotgun
   sinatra!
   sqlite3
+  state_machine
   yard (>= 0.7.0)
   yard-rspec (= 0.1)

--- a/lib/lims-api/context.rb
+++ b/lib/lims-api/context.rb
@@ -110,6 +110,13 @@ module Lims
         resource_class_for_class(object.class)
       end
 
+      # @param [Object] object underlying to the resource
+      # @param [String] name name used in the json (singular)
+      # @param [String] uuid if known
+      def resource_for(object, name, uuid=nil)
+          resource_class_for(object).new(self, Core::Uuids::UuidResource.new(:uuid => uuid),  name, object)
+      end
+
       # Computes the hash model -> Resource Class
       # It looks for a specific class in Lims::Api::Resources
       # and use as CoreResource. This method pre-compute the lookup.

--- a/lib/lims-api/core_class_resource.rb
+++ b/lib/lims-api/core_class_resource.rb
@@ -11,7 +11,8 @@ module Lims
 
       attr_reader :name, :model
 
-      # @param [String] model underlying model, part of the core
+      # @param [Class] model underlying model, part of the core
+      # @param [String] name used to generate url
       def initialize(context, model, name)
         @model = model
         @name = name
@@ -45,9 +46,7 @@ module Lims
           uuid = r.delete(:uuid)
           type = r.keys.first
           object = r[type]
-          @context.resource_class_for(object).new(@context, Core::Uuids::UuidResource.new(:uuid => uuid),  type,
-                           object)
-
+          @context.resource_for(object, type, uuid)
         end
       end
 

--- a/lib/lims-api/core_resource_page.rb
+++ b/lib/lims-api/core_resource_page.rb
@@ -1,0 +1,178 @@
+require 'state_machine'
+require 'facets/hash'
+
+require 'lims-core'
+require 'lims-api/json_encoder'
+require 'lims-api/json_decoder'
+
+require 'lims-api/resource'
+
+module Lims
+  module Api
+    class CoreResourcePage
+      include Resource
+
+      UnloadedError = Class.new(RuntimeError)
+
+      attr_reader :name, :model, :page_number, :number_per_page 
+
+      # @param [Class] model underlying model, part of the core
+      # @param [String] name used to generate url (plural then)
+      # @param [Integer] page_number
+      # @param [Integer] number_per_page
+      def initialize(context, model, name, page_number, number_per_page)
+        @model= model
+        @name = name
+        @page_number = page_number
+        @number_per_page = number_per_page
+        super(context)
+      end
+
+      state_machine :state, :initial => :unloaded do
+        event :load! do
+          transition :unloaded => :loaded
+        end
+        state :unloaded do
+          def actions
+            raise UnloadedError, "objects not loaded. Can't call method action."
+          end
+          def number_of_pages
+            raise UnloadedError, "objects not loaded. Can't call method action."
+          end
+        end
+
+        state :loaded do
+          def number_of_pages
+            @number_per_pages ||= [1, (@object_number+@number_per_page-1)/@number_per_page].max
+          end
+
+          def actions
+            %w[read].tap do |as| 
+              as << "next" if page_number < number_of_pages
+              as << "previous" if page_number > 1
+            end
+          end
+
+          # We don't provide a map operator but not only an each one
+          # to encourage lazzy/stream-friendly encoding agains map
+          # Note : the map operator can be easily be build fro this
+          def for_each_object(&block)
+            @object_iterator.each do |object|
+              resource = @context.resource_for(object, name)
+              block[resource]
+            end
+          end
+        end
+      end
+
+      def first_index
+        [(page_number-1)*(number_per_page), 0].max
+      end
+
+      def last_index
+        [first_index+number_per_page-1, [@object_number-1, 0].max].min
+      end
+
+      def load_objects(session)
+        @object_number  = @context.model_count(model)
+        @object_iterator = session.persistor_for(model).slice(first_index, last_index-first_index+1)
+        load!
+      end
+
+      #==================================================
+      # Actions
+      #==================================================
+
+      create_action(:reader) do |session|
+        load_objects(session)
+        self
+      end
+
+      #==================================================
+      # Encoders
+      #==================================================
+
+      # Specific encoder
+      module  Encoder
+        include Resource::Encoder
+
+        def to_stream(s)
+          s.tap do
+            s.start_array
+            object.for_each_object do |object|
+              object.content_to_stream(s)
+            end
+            s.end_array
+          end
+
+        end
+
+        def to_struct
+          {
+            object.name => {
+            :actions => object.actions.mash { |a| [a, url_for_action(a)] },
+            :models => to_stream(StructStream.new).struct
+          }}
+        end
+
+        def url_for_page(page_number)
+          url_for("#{object.name}?page=#{page_number}")
+        end
+
+        def url_for_action(action)
+          case action.to_sym
+          when :read
+            url_for_page(object.page_number)
+            # We don't need at that point to check the existance of previous/next page
+            # as that will be filtered by the {actions} method.
+          when :next
+            url_for_page(object.page_number+1)
+          when :previous
+            url_for_page(object.page_number-1)
+          else
+            raise RuntimeError, "Unexpected action '#{action}'"
+          end
+        end
+      end
+
+      Encoders = [
+        class JsonEncoder
+          include Encoder
+          include Lims::Api::JsonEncoder
+        end
+      ]
+      def self.encoder_class_map 
+        @encoder ||= Encoders.mash { |k| [k::ContentType, k] }
+      end
+
+      #==================================================
+      # Decoders
+      #==================================================
+
+      # Specific decoder
+      module  Decoder
+        include Resource::Decoder
+        def to_struct
+          {
+            object.name => {
+            :actions => object.actions.mash { |a| [a, url_for_action(a)] }
+          }}
+        end
+
+        def url_for_action(action)
+          url_for("#{object.name}/#{action}")
+        end
+      end
+
+      Decoders = [
+        class JsonDecoder
+          include Decoder
+          include Lims::Api::JsonDecoder
+        end
+      ]
+      def self.decoder_class_map 
+        @decoder ||= Decoders.mash { |k| [k::ContentType, k] }
+      end
+    end
+  end
+end

--- a/lib/lims-api/resource.rb
+++ b/lib/lims-api/resource.rb
@@ -16,16 +16,16 @@ module Lims::Api
     # -----------------
 
     def encoder_for(mime_types)
-      encoder_class_for(mime_types).andtap { |k| k.new(self, @context) }
+      find_encoder_class_for(mime_types).andtap { |m, k| k.new(self, k, @context) }
     end
 
 
     # find first encoder available in {EncoderClassMap}.
     # @param [Array<String>] mime_types
-    # @return [Class, nil]
-    def encoder_class_for(mime_types)
+    # @return [Array<String, Class], nil] the selected mime_type and the class
+    def find_encoder_class_for(mime_types)
       mime_types.each do |mime_type| 
-        self.class.encoder_class_map[mime_type].andtap { |k| return k }
+        self.class.encoder_class_map[mime_type].andtap { |k| return [mime_type, k] }
       end
       nil
     end
@@ -128,8 +128,9 @@ module Lims::Api
         end
       end
 
-      def initialize(object, context)
+      def initialize(object, mime_type,  context)
         @object = object      
+        @mime_type = mime_type
         @context = context
       end
 

--- a/lib/lims-api/resources/plate_resource.rb
+++ b/lib/lims-api/resources/plate_resource.rb
@@ -26,12 +26,15 @@ module Lims::Api
         s.tap do
           s.start_hash
           s.add_key "plate"
-          s.start_hash
-          s.add_key "wells"
-          wells_to_stream(s)
-          s.end_hash
+          content_to_stream(s)
           s.end_hash
         end
+      end
+      def content_to_stream(s)
+        s.start_hash
+        s.add_key "wells"
+        wells_to_stream(s)
+        s.end_hash
       end
 
       def wells_to_stream(s)

--- a/lims-api.gemspec
+++ b/lims-api.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sequel')
   s.add_dependency('json')
   s.add_dependency('active_support') # inflectors only
+  s.add_development_dependency('state_machine')
 
   s.add_development_dependency('rake', '~> 0.9.2')
   s.add_development_dependency('rspec', '~> 2.8.0')

--- a/spec/lims-api/core_resource_page_spec.rb
+++ b/spec/lims-api/core_resource_page_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+require 'lims-api/resource_shared'
+
+require 'lims-api/core_resource_page'
+
+module Lims::Api
+  shared_context "no models" do
+    let(:models) { [] }
+  end
+
+  shared_context "with models" do
+    let(:models) { 1.upto(45).map { |i| model_class.new(i) } } 
+  end
+
+  shared_context "page" do |page_number|
+    let(:page_number) { page_number }
+  end
+
+  shared_examples_for "page resource" do |response|
+    context "unloaded" do
+      it do
+        expect { subject.actions}.to raise_error(CoreResourcePage::UnloadedError)
+      end
+
+      its(:state) { should == "unloaded" }
+    end
+
+    context "loaded" do
+      before (:each) {
+        session = mock(:session)
+        session.stub_chain(:persistor_for, :slice) { |first, last| models[first, last] }
+        resource.load_objects(session)
+      }
+
+      its(:state) { should == "loaded" }
+      its(:actions) { should be_a(Array) }
+
+      context "::JSonEncoder" do
+        subject { resource.encoder_for(['application/json']) }
+        it "return a list of actions" do
+          subject.call.should match_json( "models" => response)
+        end
+      end
+    end
+  end
+
+  describe CoreResourcePage do
+    def self.validate_number_of_pages(object_number, number_per_page, number_of_pages)
+      context "#page number (objects = #{object_number}, number per page = #{number_per_page})" do
+        let(:context) { mock(:context).tap do |c|
+          c.stub(:model_count) { object_number }
+        end
+        }
+        let(:session) { mock(:session).tap do |s|
+          s.stub_chain(:persistor_for, :slice) { [] }
+        end
+        }
+        subject{ described_class.new(context, nil, nil, 0, number_per_page) }
+        it "computes the correct number of pages" do
+          subject.load_objects(session)
+          subject.number_of_pages.should== number_of_pages
+        end
+      end
+    end
+
+    validate_number_of_pages 0, 10, 1
+    validate_number_of_pages 10, 10, 1
+    validate_number_of_pages 11, 10, 2
+
+
+    def self.validate_index_range(object_number, number_per_page, page_number, first, last)
+      context "#page number (objects = #{object_number}, number per page = #{number_per_page}, page = #{page_number})" do
+        let(:context) { mock(:context).tap do |c|
+          c.stub(:model_count) { object_number }
+        end
+        }
+        let(:session) { mock(:session).tap do |s|
+          s.stub_chain(:persistor_for, :slice) { [] }
+        end
+        }
+        subject{ described_class.new(context, nil, nil, page_number, number_per_page) }
+        it "computes the correct pages range" do
+          subject.load_objects(session)
+          subject.first_index.should == first
+          subject.last_index.should == last
+        end
+      end
+    end
+    validate_index_range 0, 10, 1, 0, 0
+    validate_index_range 5, 10, 1, 0, 4
+    validate_index_range 45, 10, 2, 10, 19
+    validate_index_range 45, 10, 5, 40, 44
+
+    context "within a valid context" do
+      let(:store) { mock(:store) }
+      let(:server_context) {
+        Context.new(store, lambda { |u| "/#{u}" })
+      }
+      let(:model_class) {
+        class Model
+          attr_reader :n
+          def initialize(i)
+            @n = i
+          end
+        end
+
+      server_context.stub(:resource_class_for) {
+        class ModelResource < CoreResource
+          def content_to_stream(s)
+            s.add_value object.n
+          end
+        end
+      ModelResource
+
+      }
+      Model
+
+      }
+      let(:model) { "models" }
+      let(:number_per_page) { 10 }
+      let(:number_of_pages) { 5}
+      let(:resource) { described_class.new(server_context, model_class, model, page_number, number_per_page) }
+      subject { resource }
+      before (:each) { server_context.stub(:model_count).and_return(models.size) }
+
+      context "no underlying models" do
+        include_context "no models"
+        context "page 1" do
+          include_context "page", 1
+          it_behaves_like "page resource", {
+            "actions" => {
+            "read" => "/models?page=1"
+            # no previous page
+            # no next page
+          },
+            "models" => [
+          ]
+          }
+        end
+
+        context "with underlying models" do
+          include_context "with models"
+          context "first page" do
+            include_context "page", 1
+            it_behaves_like "page resource", {
+              "actions" => {
+              "read" => "/models?page=1",
+              # no previous page
+              "next" => "/models?page=2"
+            },
+              "models" => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            }
+          end
+          context "last page" do
+            include_context "page", 5
+            it_behaves_like "page resource", {
+              "actions" => {
+              "read" => "/models?page=5",
+              "previous" => "/models?page=4"
+              # no next page
+            },
+              "models" => [41, 42, 43, 44, 45]
+            }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needs to be tested in real life.

compile.

[WIP] Add 'follow_link' to specs

To follow 'next' and 'previous' pages.

Refactors CoreResourcePage specs.

Update CoreResourcePage. Specs compile  but fail.

Add page number computation and state machine to Page

test regarding number of pages pass.
JSON fails.

Spec run but fails

first and last index work (with spec.)

Empty model spec pass as well.

Add Context#resource_for

Pass mime-type to encoder

Almost work

9 item displayed instead of 10.

Work but model instead of models (we need to decide)

!!! All spec pass (for CoreResourcePage)
