### PR TITLE
[#38342385] Use Plate's renamed number_of_columns/rows property

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 # because it fixes some of the 'after' callback handling so that the request is correctly
 # available.
 gem 'sinatra', :git => 'git@github.com:sinatra/sinatra.git'
-gem 'lims-core', '~>0.10.0', :git => 'git@github.com:sanger/lims-core.git' , :branch => 'development'
+gem 'lims-core', '~>0.11.0', :git => 'git@github.com:sanger/lims-core.git' , :branch => 'development'
 #gem 'lims-core', :path => '../lims-core'
 
 group :guard do

--- a/db/migrations/001_create_tables.rb
+++ b/db/migrations/001_create_tables.rb
@@ -28,8 +28,8 @@ Sequel.migration do
 
     create_table :plates do
       primary_key :id
-      Integer :row_number
-      Integer :column_number
+      Integer :number_of_rows
+      Integer :number_of_columns
     end
 
     create_table :wells do

--- a/spec/integrations/plate_spec.rb
+++ b/spec/integrations/plate_spec.rb
@@ -9,8 +9,8 @@ require 'integrations/spec_helper'
 
 def create_well_hash
   {}.tap do |h| 
-    (1..row_number).each do |r|
-      (1..column_number).each do |c|
+    (1..number_of_rows).each do |r|
+      (1..number_of_columns).each do |c|
         h["#{(?A.ord+r-1).chr}#{c}"]=[]
       end
     end
@@ -36,10 +36,10 @@ shared_context "expect plate JSON" do
   }
 end
 
-shared_context "has dimension" do |row_number, column_number| 
-  let(:row_number) { row_number }
-  let(:column_number) { column_number }
-  let(:dimension) { {:row_number => row_number, :column_number => column_number} }
+shared_context "has dimension" do |number_of_rows, number_of_columns|
+  let(:number_of_rows) { number_of_rows }
+  let(:number_of_columns) { number_of_columns }
+  let(:dimension) { {:number_of_rows => number_of_rows, :number_of_columns => number_of_columns} }
 end
 
 shared_context "has standard dimension" do
@@ -61,7 +61,7 @@ shared_context "for plate with samples" do
 end
 
 shared_examples_for "with saved plate with samples" do
-  subject { described_class.new(:row_number => 8, :column_number => 12) }
+  subject { described_class.new(:number_of_rows => 8, :number_of_columns => 12) }
   let (:sample_location) { :C5 }
   include_context "with sample in location"
 end
@@ -155,7 +155,7 @@ describe Lims::Core::Laboratory::Plate do
       context "to an existing target", :focus  => true do
         let(:target_uuid) {     '11111111-2222-3333-1111-000000000000'.tap do |uuid|
           store.with_session do |session|
-            plate = Lims::Core::Laboratory::Plate.new(:row_number => 8, :column_number => 12)
+            plate = Lims::Core::Laboratory::Plate.new(:number_of_rows => 8, :number_of_columns => 12)
             session << plate
             set_uuid(session, plate, uuid)
           end

--- a/test_script/create_empty_plate.sh
+++ b/test_script/create_empty_plate.sh
@@ -1,4 +1,4 @@
 curl -H 'Content-type:application/json' -H 'Accept:application/json' \
        	http://localhost:9292/plates \
-       	-d '{"row_number":8, "column_number":12}'
+       	-d '{"number_of_rows":8, "number_of_columns":12}'
 

--- a/test_script/create_plate.sh
+++ b/test_script/create_plate.sh
@@ -1,6 +1,6 @@
 curl -H 'Content-type:application/json' -H 'Accept:application/json' \
        	http://localhost:9292/plates \
-	-d '{"row_number":8, "column_number":12, "wells_description":{
+	-d '{"number_of_rows":8, "number_of_columns":12, "wells_description":{
 		"A12":[{"sample_uuid" :"11111111-0000-1111-0000-111111111111"}, {"sample_uuid"
 		:"66666666-0000-1111-0000-111111111111"} ], "B11":[{"sample_uuid"
 		:"22222222-0000-1111-0000-111111111111"}], "C10":[{"sample_uuid"


### PR DESCRIPTION
Plate resource's row/column_number properties
has been renamed in the lims-core module. We have to
use the new names of these properties.
In the DB the Plates table related fields 
has been renamed, too.
