### PR TITLE
39857931 update order via the api

### DIFF
--- a/lib/lims-api/core_resource.rb
+++ b/lib/lims-api/core_resource.rb
@@ -1,5 +1,6 @@
 require 'lims-core'
 require 'lims-api/json_encoder'
+require 'lims-api/json_decoder'
 
 require 'lims-api/resource'
 require 'lims-api/struct_stream'
@@ -14,11 +15,11 @@ module Lims::Api
   # Example : if defined Laboratory::Plate will use Lims::Api::Resources::PlateResource.
   class CoreResource
     include Resource
-    attr_reader :model_name 
-    # @param [Core::Uuids::UuidResource] uuid_resource  a _link_ between the object and the database.
+    attr_reader :model_name
+    # @param [Core::Uuids::UuidResource] uuid_resource a _link_ between the object and the database.
     # @param [String] model_name, the model name (used in URL generation)
     # @param [Resource, Nil] object if already in memory
-    def initialize(context, uuid_resource, model_name,  object=nil)
+    def initialize(context, uuid_resource, model_name, object=nil)
       @uuid_resource = uuid_resource
       @model_name = model_name
       @object = object
@@ -60,11 +61,25 @@ module Lims::Api
       self
     end
 
-    create_action(:updater) do |session, attributes|
-      object(session).tap do |o|
-        o.update(attributes)
-      end
-      self
+    def updater(attributes)
+      lambda {
+        model_class = @context.find_model_class(model_name)
+        raise "Wrong model" unless model_class
+        action_class = model_class::Update
+        action = @context.create_action(action_class, attributes.merge(:order_uuid => uuid))
+        result = @context.execute_action(action)
+
+        # We remove the uuid key so the only remaining one
+        # is the object itself
+        new_uuid = result.delete(:uuid)
+        type = result.keys.first
+        object = result[type]
+
+        # we probably could use the resource itself
+        #
+        # instead of creating a new one
+        @context.resource_for(object, type, new_uuid)
+      }
     end
 
     create_action(:deleter) do |session|
@@ -82,7 +97,7 @@ module Lims::Api
     #==================================================
 
     # Specific encoder
-    module  Encoder
+    module Encoder
       include Resource::Encoder
       def to_stream(s)
         s.tap do
@@ -111,11 +126,30 @@ module Lims::Api
       class JsonEncoder
         include Encoder
         include Lims::Api::JsonEncoder
-      end
+    end
     ]
 
-    def self.encoder_class_map 
+    def self.encoder_class_map
       Encoders.mash { |k| [k::ContentType, k] }
+    end
+
+    #==================================================
+    # Decoders
+    #==================================================
+
+    # Specific decoder
+    module Decoder
+      include Resource::Decoder
+    end
+
+    Decoders = [
+      class JsonDecoder
+        include Decoder
+        include Lims::Api::JsonDecoder
+    end
+    ]
+    def self.decoder_class_map
+      @decoder ||= Decoders.mash { |k| [k::ContentType, k] }
     end
   end
 end

--- a/spec/integrations/order_spec.rb
+++ b/spec/integrations/order_spec.rb
@@ -8,103 +8,263 @@ require 'lims-core/persistence/sequel'
 require 'integrations/lab_resource_shared'
 require 'integrations/spec_helper'
 
+module Lims::Core
 
-describe Lims::Core::Organization::Order do
-  include_context "use core context service", :items, :orders, :studies, :users, :uuid_resources 
-  include_context "JSON"
+  shared_context "json order" do
+    let(:expected_json) {
+          action_url = "http://example.org/#{uuid}"
+          user_url = "http://example.org/#{user_uuid}"
+          study_url = "http://example.org/#{study_uuid}"
 
-  context "create an order" do
+          {:order => {
+            :actions => {:read => action_url, :create => action_url, :update => action_url, :delete => action_url},
+            :uuid => uuid, 
+            :creator => {
+              :actions => {:read => user_url, :create => user_url, :update => user_url, :delete => user_url},
+              :uuid => user_uuid 
+            },
+            :pipeline => order_pipeline,
+            :status => order_status,
+            :parameters => order_parameters,
+            :state => order_state,
+            :study => {
+              :actions => {:create => study_url, :delete => study_url, :read => study_url, :update => study_url},
+              :uuid => study_uuid 
+            },
+            :cost_code => order_cost_code,
+            :items => order_items
+          }}
+    }  
+  end
 
-    context "with empty parameters" do
-      let(:url) { "/actions/create_order" }
-      let(:parameters) { {} }
-      let(:expected_json) { {"errors" => {"study" => "invalid", "cost_code" => "invalid"}} }
-      it_behaves_like "an invalid core action", 422
-    end
-
-
-    context "with correct parameters" do
-      include_context "use generated uuid"
-      
-      let(:url) { "/orders" }
-      let(:study_uuid) { "55555555-2222-3333-6666-777777777777".tap do |uuid|
-        store.with_session do |session|
-          study = Lims::Core::Organization::Study.new
-          set_uuid(session, study, uuid)
-        end
+  shared_context "set user and study uuid" do
+    let(:study_uuid) { "55555555-2222-3333-6666-777777777777".tap do |uuid|
+      store.with_session do |session|
+        study = Lims::Core::Organization::Study.new
+        set_uuid(session, study, uuid)
       end
-      } 
-
-      let(:user_uuid) { "66666666-2222-4444-9999-000000000000".tap do |uuid|
-        store.with_session do |session|
-          user = Lims::Core::Organization::User.new
-          set_uuid(session, user, uuid)
-        end
-      end
-      }
-
-      let(:cost_code) { "cost code" }
-      let(:pipeline) { "pipeline" }
-      let(:sources) { {:source_role1 => "99999999-2222-4444-9999-000000000000"} }
-      let(:targets) { {:target_role1 => "99999999-2222-4444-9999-111111111111" } }
-      let(:parameters) { {:order => {:user_uuid => user_uuid,
-        :study_uuid => study_uuid,
-        :sources => sources, 
-        :targets => targets,
-        :cost_code => cost_code,
-        :pipeline => pipeline}} }
-
-      let(:expected_json) { 
-        action_url = "http://example.org/#{uuid}"
-        user_url = "http://example.org/#{user_uuid}"
-        study_url = "http://example.org/#{study_uuid}"
-
-        {:order => {
-          :actions => {
-            :read => action_url,
-            :create => action_url,
-            :update => action_url,
-            :delete => action_url
-          },
-          :uuid => uuid, 
-          :creator => {
-            :actions => {
-              :read => user_url,
-              :create => user_url,
-              :update => user_url,
-              :delete => user_url 
-            },
-          :uuid => user_uuid 
-          },
-          :pipeline => pipeline,
-          :status => "draft",
-          :parameters => {  },
-          :state => {  },
-          :study => {
-            :actions => {
-              :create => study_url,
-              :delete => study_url,
-              :read => study_url,
-              :update => study_url
-            },
-          :uuid => study_uuid 
-          },
-          :cost_code => cost_code,
-          :items => {
-            :source_role1 => {
-              :status => "done",
-              :uuid => "99999999-2222-4444-9999-000000000000"
-            },
-            :target_role1 => {
-              :status => "pending",
-              :uuid => "99999999-2222-4444-9999-111111111111"
-            }
-          } 
-         }}
-      }
-
-      it_behaves_like "a valid core action" do
-      end 
     end
+    } 
+
+    let(:user_uuid) { "66666666-2222-4444-9999-000000000000".tap do |uuid|
+      store.with_session do |session|
+        user = Lims::Core::Organization::User.new
+        set_uuid(session, user, uuid)
+      end
+    end
+    }
   end 
+
+  shared_examples_for "updated order" do
+    it "succeeds to update the order" do
+      update_action.status.should == 200 
+    end
+
+    it "returns the expected json" do
+      update_action.body.should match_json(expected_json) 
+    end
+
+    it "update the object" do
+      body = JSON::parse(update_action.body)
+      body["order"]["uuid"].should == uuid
+      body["order"]["actions"]["read"].should == "http://example.org#{url}"
+
+      reloaded_order = get url
+      reloaded_order.status.should == 200
+      reloaded_order.body.should match_json(expected_json)
+    end
+  end
+
+
+  shared_context "save order" do |uuid|
+    let!(:uuid) {
+      store.with_session do |session|
+        order_items.each do |role, item|
+          order[role] = item
+        end
+        set_uuid(session, order, uuid)
+        set_uuid(session, order.creator, user_uuid)
+        set_uuid(session, order.study, study_uuid)
+      end
+      uuid
+    }
+  end
+
+
+  shared_context "setup order" do |*events|
+    let(:order) { 
+      described_class.new(:creator => Organization::User.new(), :study => Organization::Study.new()).tap { |o| 
+        if events
+          events.each do |event|
+            o.send(event)
+          end
+        end 
+        }}
+  end
+
+
+  shared_context "update order" do
+    let(:update_action) { put url, update_parameters.to_json }  
+  end
+
+  shared_examples_for "doesn't accept event" do |event|
+    context event do
+      let(:update_parameters) { {:event => event} }
+      include_context "update order"
+      it { update_action.status.should == 500 }
+    end
+  end
+
+  shared_examples_for "accept event and change status" do |event, status|
+    context event do
+      let(:update_parameters) {{:event => event} }
+      include_context "update order"
+
+      it "accept event" do
+        update_action.status.should == 200 
+      end
+
+      it "change status" do
+        body = JSON::parse(update_action.body)
+        body["order"]["status"].should == status
+      end 
+    end 
+  end
+
+  shared_examples_for "modify order" do |event, status|
+    context event do
+      let(:update_parameters) { {:event => event} }
+      include_context "update order"   
+      include_context "json order"
+
+      let(:order_status) { status }
+      let(:order_parameters) { {} }
+      let(:order_state) { {} }
+      let(:order_pipeline) { order.pipeline }
+      let(:order_cost_code) { order.cost_code }
+
+      it_behaves_like "updated order"  
+    end
+  end
+
+  shared_examples_for "not updating variable" do |key|
+    include_context "update order"
+    context key do
+      let(:update_parameters) { {key => "value"}}
+      it "fail" do
+        expect { update_action }.to raise_error 
+      end
+    end    
+  end
+
+  shared_examples_for "updating variable" do |key, value|
+    include_context "update order"
+    context key do
+      let(:update_parameters) { {key => value} }
+      it {
+        body = JSON::parse(update_action.body)
+        body["order"][key.to_s].should == value
+      }
+    end
+  end
+
+  describe Organization::Order do
+    include_context "use core context service", :items, :orders, :studies, :users, :uuid_resources 
+    include_context "JSON"
+
+    context "#create" do
+      include_context "set user and study uuid"
+      
+      context "with empty parameters" do
+        let(:url) { "/actions/create_order" }
+        let(:parameters) { {} }
+        let(:expected_json) { {"errors" => {"study" => "invalid", "cost_code" => "invalid"}} }
+        it_behaves_like "an invalid core action", 422
+      end
+
+      context "with correct parameters" do
+        include_context "use generated uuid"
+        include_context "json order"
+        let(:url) { "/orders" }
+        let(:order_items) { {
+          :source_role1 => { :status => "done", :uuid => "99999999-2222-4444-9999-000000000000"},
+          :target_role1 => { :status => "pending", :uuid => "99999999-2222-4444-9999-111111111111"}} 
+        }
+        let(:order_parameters) { {} }
+        let(:order_state) { {} }
+        let(:order_status) { "draft" }
+        let(:order_cost_code) { "cost code" }
+        let(:order_pipeline) { "pipeline" }
+        let(:sources) { {:source_role1 => "99999999-2222-4444-9999-000000000000"} }
+        let(:targets) { {:target_role1 => "99999999-2222-4444-9999-111111111111" } }
+        let(:parameters) { {:order => {:user_uuid => user_uuid, :study_uuid => study_uuid, :sources => sources, :targets => targets, :cost_code => order_cost_code, :pipeline => order_pipeline}} }
+        it_behaves_like "a valid core action" do
+        end 
+      end
+    end 
+
+    context "#update" do
+      include_context "save order", "11111111-2222-3333-4444-555555555555"
+      let(:url) { "/#{uuid}" }
+      let(:study_uuid) { "55555555-2222-3333-6666-777777777777" }
+      let(:user_uuid) { "66666666-2222-4444-9999-000000000000" }
+
+      context "draft order" do
+        include_context "setup order"
+        let(:order_items) { {} }
+        it { order.status.should == "draft" }
+        it_behaves_like "doesn't accept event", :start
+        it_behaves_like "accept event and change status", :build, "pending"
+        it_behaves_like "updating variable", :pipeline, "new pipeline"
+        it_behaves_like "modify order", :build, "pending"
+      end
+
+      context "pending order" do
+        include_context "setup order", :build
+        let(:order_items) { {} }
+        it { order.status.should == "pending" }
+
+        context "with items" do
+          #let(:order_items____) { { "pending" => Organization::Order::Item.new(:uuid => "pending uuid"),
+          # "in_progress" => Organization::Order::Item.new(:uuid => "in_progress uuid").tap { |i| i.start! },
+          # "done" => Organization::Order::Item.new(:uuid => "done uuid").tap { |i| i.complete! } } }
+
+          it_behaves_like "doesn't accept event", :build
+          it_behaves_like "accept event and change status", :start, "in_progress"
+          it_behaves_like "modify order", :start, "in_progress"
+        end
+      end
+
+      context "in_progress order" do
+        include_context "setup order", :build, :start
+        let(:order_items) { {} }
+        it { order.status.should == "in_progress" }
+        it_behaves_like "doesn't accept event", :build
+        it_behaves_like "accept event and change status", :complete, "completed"
+        it_behaves_like "modify order", :complete, "completed"
+        #it_behaves_like "not updating variable", :creator
+      end
+
+      context "failed order" do
+        include_context "setup order", :build, :start, :fail
+        let(:order_items) { {} }
+        it { order.status.should == "failed" }
+        it_behaves_like "doesn't accept event", :complete
+      end
+
+      context "completed order" do
+        include_context "setup order", :build, :start, :complete
+        let(:order_items) { {} }
+        it { order.status.should == "completed" }
+        it_behaves_like "doesn't accept event", :complete
+      end
+
+      context "cancel order" do
+        include_context "setup order", :build, :start, :cancel
+        let(:order_items) { {} }
+        it { order.status.should == "cancel" }
+        it_behaves_like "doesn't accept event", :start
+      end
+    end
+  end
 end

--- a/spec/lims-api/core_resource_spec.rb
+++ b/spec/lims-api/core_resource_spec.rb
@@ -34,7 +34,7 @@ shared_examples_for "updatable" do
   let(:attributes) { {:name => "B" } }
   it do
     model.should_receive(:update).with(attributes)
-    resource.updater(attributes ).call.should == resource
+    resource.updater(attributes).call.should == resource
   end
 end
 

--- a/spec/lims-api/core_resource_spec.rb
+++ b/spec/lims-api/core_resource_spec.rb
@@ -32,8 +32,13 @@ end
 
 shared_examples_for "updatable" do
   let(:attributes) { {:name => "B" } }
+  let(:model_class) { Lims::Core::Organization::Order }
   it do
-    model.should_receive(:update).with(attributes)
+    #model.should_receive(:update).with(attributes)
+    server_context.stub(:find_model_class) { |a| model_class }
+    server_context.stub(:create_action)
+    server_context.stub(:execute_action) { {} }
+    server_context.stub(:resource_for) { resource }
     resource.updater(attributes).call.should == resource
   end
 end

--- a/spec/lims-api/resource_shared.rb
+++ b/spec/lims-api/resource_shared.rb
@@ -6,10 +6,6 @@ shared_context "mock context" do
       context.stub(:url_for)  { |url| "/#{url}"  }
       context.stub(:recursively_lookup_uuid) { |a| a }
       #context.stub(:last_session) { mock(:last_session) }
-      #context.stub(:find_model_class) { |a| Lims::Core::Organization::Order }
-      #context.stub(:create_action)   
-      #context.stub(:execute_action) { {} }
-      #context.stub(:resource_for) { resource }
     end
   }
 end

--- a/spec/lims-api/resource_shared.rb
+++ b/spec/lims-api/resource_shared.rb
@@ -1,13 +1,17 @@
 require 'lims-api/context'
 shared_context "mock context" do
-        let!(:server_context) {
-          #Context.new(store, lambda { |url| "/#{url}"  }).tap do |context|
-          mock(:context).tap do |context|
-          context.stub(:url_for)  { |url| "/#{url}"  }
-          context.stub(:recursively_lookup_uuid) { |a| a }
-          #context.stub(:last_session) { mock(:last_session) }
-          end
-        }
+  let!(:server_context) {
+    #Context.new(store, lambda { |url| "/#{url}"  }).tap do |context|
+    mock(:context).tap do |context|
+      context.stub(:url_for)  { |url| "/#{url}"  }
+      context.stub(:recursively_lookup_uuid) { |a| a }
+      #context.stub(:last_session) { mock(:last_session) }
+      #context.stub(:find_model_class) { |a| Lims::Core::Organization::Order }
+      #context.stub(:create_action)   
+      #context.stub(:execute_action) { {} }
+      #context.stub(:resource_for) { resource }
+    end
+  }
 end
 
 shared_context "with filled aliquots" do


### PR DESCRIPTION
The specs pass. In the spec lims-api/core_resource_spec.rb, I needed to change the shared_examples_for "updatable" to make it work with the new method updater in the core_resource.rb. I know the model_class is set to Lims::Core::Organization::Order and It should be more generic, but couldn't find a way to do it so far. Any suggestions?
