### PR TITLE
[fixes #40924617] Custom resource for CreatePlate action

### DIFF
--- a/lib/lims-api/resources/create_plate_resource.rb
+++ b/lib/lims-api/resources/create_plate_resource.rb
@@ -1,0 +1,32 @@
+require 'lims-api/core_action_resource'
+require 'lims-api/struct_stream'
+
+module Lims::Api
+  module Resources
+    class CreatePlateResource < CoreActionResource
+      UUID_FIELDS_IN_ALIQUOT = [ 'sample', 'tag' ]
+
+      # Utility method for ensuring that the UUID fields in each aliquot of the well description
+      # hash is mapped correctly.  The block controls the direction of the mapping.
+      def self.map_well_descriptions(wells_description, &block)
+        wells_description.update_values do |aliquots|
+          aliquots.map do |aliquot|
+            aliquot.update(aliquot.subset(UUID_FIELDS_IN_ALIQUOT).update_values(&block))
+          end
+        end unless wells_description.nil?
+      end
+
+      def self.filter_attributes_on_create(attributes, context, session)
+        super.tap do |new_attributes|
+          map_well_descriptions(new_attributes['wells_description']) { |v| session[v] }
+        end
+      end
+
+      def filtered_attributes
+        super.tap do |attributes|
+          self.class.map_well_descriptions(attributes[:wells_description]) { |v| @context.uuid_for(v) || v }
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/plate_spec.rb
+++ b/spec/integrations/plate_spec.rb
@@ -48,7 +48,7 @@ shared_context "for plate with samples" do
   let (:parameters) { { :plate => dimensions.merge(:wells_description => wells_description) } }
   include_context "with saved sample"
   include_context "with filled aliquots"
-  let(:wells_description) { { "C5" => [{"sample_uuid" => sample_uuid }] } }
+  let(:wells_description) { { "C5" => [{"sample" => sample_uuid }] } }
   let(:wells_description_response) { { "C5" => aliquot_array } }
   let(:well_hash) { create_well_hash.merge(wells_description_response) }
 end


### PR DESCRIPTION
We need to map the UUIDs contained within the JSON for a CreatePlate
action appropriately, so that they become the appropriate sample or tag.
