### PR TITLE
[#40345057] Disable Sinatra exception handling

### DIFF
--- a/lib/lims-api/server.rb
+++ b/lib/lims-api/server.rb
@@ -5,6 +5,10 @@ require 'sinatra'
 module Lims
   module Api
     class Server < Sinatra::Base
+      # Irrespective of the environment, we always want our exceptions handled internally, and
+      # not by Sinatra itself, nor do we want them to escape the server.
+      set(:raise_errors, false)
+
       # @method request_method(*types)
       # @scope class
       #


### PR DESCRIPTION
To prevent Travis CI from failing, and to ensure that the correct
behaviour is maintained in all environments, do not allow exceptions to
be handled by Sinatra.
