### PR TITLE
[fix #49131067] upgraded bunny gem to 0.9.0.pre10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gemspec
 # because it fixes some of the 'after' callback handling so that the request is correctly
 # available.
 gem 'sinatra', :git => 'http://github.com/sinatra/sinatra.git', :branch => '459369eb66224836f72e21bbece58c007f3422fa'
-gem 'lims-core', '~>1.5.0.1', :git => 'http://github.com/sanger/lims-core.git' , :branch => 'development'
+gem 'lims-core', '~>1.5', :git => 'http://github.com/sanger/lims-core.git' , :branch => 'development'
+# gem 'lims-core', '~>1.5', :path => '../lims-core'
 
 group :guard do
   gem "guard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: http://github.com/sanger/lims-core.git
-  revision: 029f0967aeb73f506dcef909314556acba5a5ec3
+  revision: dbefac2ae5491f120c2fbe1944bc232f8835450e
   branch: development
   specs:
-    lims-core (1.5.0.1.4)
+    lims-core (1.5.0.3.0)
       active_support
       aequitas
-      bunny (= 0.9.0.pre4)
+      bunny (= 0.9.0.pre10)
       facets (= 2.9.3)
       sequel
       state_machine
@@ -32,9 +32,9 @@ GIT
 PATH
   remote: .
   specs:
-    lims-api (1.2.0.2.5)
+    lims-api (1.2.0.3.0)
       active_support
-      bunny (= 0.9.0.pre4)
+      bunny (= 0.9.0.pre10)
       json
       sequel
       state_machine
@@ -46,11 +46,11 @@ GEM
       activesupport (= 3.0.0)
     activesupport (3.0.0)
     aequitas (0.0.2)
-    amq-protocol (1.3.0)
+    amq-protocol (1.4.0)
     bond (0.4.3)
     bond (0.4.3-java)
-    bunny (0.9.0.pre4)
-      amq-protocol (>= 1.0.1)
+    bunny (0.9.0.pre10)
+      amq-protocol (>= 1.4.0)
     coderay (1.0.8)
     columnize (0.3.6)
     debugger (1.2.4)
@@ -117,7 +117,7 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    sequel (3.46.0)
+    sequel (3.47.0)
     shotgun (0.9)
       rack (>= 1.0)
     slop (3.4.3)
@@ -157,7 +157,7 @@ DEPENDENCIES
   guard-yard
   hashdiff
   lims-api!
-  lims-core (~> 1.5.0.1)!
+  lims-core (~> 1.5)!
   mysql2
   pry
   psd_logger!

--- a/config/amqp.yml
+++ b/config/amqp.yml
@@ -4,6 +4,9 @@ defaults: &defaults
   durable: true
   message_persistent: true
   prefetch_number: 1
+  # You can define a heart_beat value, then the bunny client will use this value.
+  # If you do not define the heart_beat value, then the bunny client will use the value provided by the RabbitMQ server.
+  #heart_beat: 0
 
 test:
   <<: *defaults

--- a/config/amqp.yml
+++ b/config/amqp.yml
@@ -4,7 +4,6 @@ defaults: &defaults
   durable: true
   message_persistent: true
   prefetch_number: 1
-  heart_beat: 0
 
 test:
   <<: *defaults

--- a/lib/lims-api/version.rb
+++ b/lib/lims-api/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module Api
-    VERSION = "1.2.0.2.5"
+    VERSION = "1.2.0.3.0"
   end
 end

--- a/lims-api.gemspec
+++ b/lims-api.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('github-markup', '~> 0.7.1')
 
   s.add_development_dependency('sqlite3')
-  s.add_dependency('bunny', '0.9.0.pre4')
+  s.add_dependency('bunny', '0.9.0.pre10')
 end


### PR DESCRIPTION
I also removed heart_beat setting from amqp.yml config file with this commit.

If there a heart_beat setting in amqp.yml config file, then the bunny will use that value, if there is no such setting, then it will use the heart_beat value provided by the RabbitMQ server.
