### PR TITLE
50803249 remove unnecessary keys in the json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-api (2.1.0.1.0)
+    lims-api (2.1.0.1.2)
       active_support
       bunny (= 0.9.0.pre10)
       json
@@ -91,8 +91,7 @@ GEM
       yard (>= 0.7.0)
     hashdiff (0.0.5)
     jruby-rack (1.1.13.1)
-    json (1.7.7)
-    json (1.7.7-java)
+    json (1.8.0)
     listen (0.7.2)
     lumberjack (1.0.2)
     macaddr (1.6.1)

--- a/lib/lims-api/context.rb
+++ b/lib/lims-api/context.rb
@@ -223,6 +223,7 @@ module Lims
       end
 
       # Replace recursively key/value pairs corresponding to an uuid by the corresponding resource pair
+      # If the resource associated to the uuid doesn't exist, we keep the uuid.
       # @example
       # { :sample_uuid => '134'} => { :sample => SampleResource }
       # @param [Hash<String,Arrays>] a structure
@@ -232,7 +233,8 @@ module Lims
         attributes.mashr do |k, v|
           case k
           when /(.*)_uuid\Z/
-            [$1, session[v]]
+            resource = session[v]
+            resource ? [$1, resource] : [k,v]
           else
             [k,v]
           end

--- a/lib/lims-api/version.rb
+++ b/lib/lims-api/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module Api
-    VERSION = "2.1.0.1.1"
+    VERSION = "2.1.0.1.2"
   end
 end


### PR DESCRIPTION
Fix the json for bulk actions to have:
result:{
  tubes: [tube1, tube2, tube3]
}
instead of
result:{
  tubes: [{tube: tube1}, {tube: tube2}, {tube: tube3}]
}

AND

When we have in the json a parameter like "sample_uuid", the method recursively_load_uuid replaces it with "sample" and the core resource. In the case the resource cannot be found, we keep the information "sample_uuid" in the parameter.
