### PR TITLE
52311811 add the application in the message metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 # because it fixes some of the 'after' callback handling so that the request is correctly
 # available.
 gem 'sinatra', :git => 'http://github.com/sinatra/sinatra.git', :branch => '459369eb66224836f72e21bbece58c007f3422fa'
-gem 'lims-core', '~>2.2', :git => 'http://github.com/sanger/lims-core.git' , :branch => 'master'
+gem 'lims-core', '~>2.3', :git => 'http://github.com/sanger/lims-core.git' , :branch => 'master'
 #gem 'lims-core', :path => '../lims-core'
 
 group :guard do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: http://github.com/sanger/lims-core.git
-  revision: d565f64278df6f9ca46836710e312e06cf073ef7
+  revision: 4a0bb4e7a873552cd7655c3d54eaa1063cecb00f
   branch: master
   specs:
-    lims-core (2.2.0)
+    lims-core (2.3.0)
       active_support
       aequitas
       bunny (= 0.9.0.pre10)
@@ -33,7 +33,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-api (2.3.0)
+    lims-api (2.4.0)
       active_support
       bunny (= 0.9.0.pre10)
       json
@@ -165,7 +165,7 @@ DEPENDENCIES
   hashdiff
   jdbc-mysql
   lims-api!
-  lims-core (~> 2.2)!
+  lims-core (~> 2.3)!
   pry
   psd_logger!
   rack-test (~> 0.6.1)

--- a/lib/lims-api/context_service.rb
+++ b/lib/lims-api/context_service.rb
@@ -5,9 +5,11 @@ module Lims::Api
   class ContextService
     # @param [Lims::Core::Persistence::Store] store  
     # @param [Lims::Core::Persistence::MessageBus] message bus
-    def initialize(store, message_bus)
+    # @param [String,Nil] application_id
+    def initialize(store, message_bus, application_id=nil)
       @store = store
       @message_bus = message_bus
+      @application_id = application_id
     end
 
     # Called by the server to create the appropriate context depending of the request.
@@ -15,7 +17,7 @@ module Lims::Api
     # or client etc ...
     # @return [Context]
     def new(request, url_generator)
-      Context.new(@store, @message_bus, url_generator)
+      Context.new(@store, @message_bus, @application_id, url_generator)
     end
   end
 end

--- a/lib/lims-api/version.rb
+++ b/lib/lims-api/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module Api
-    VERSION = "2.3.0"
+    VERSION = "2.4.0"
   end
 end

--- a/spec/lims-api/context_spec.rb
+++ b/spec/lims-api/context_spec.rb
@@ -23,7 +23,7 @@ end
 module Lims::Api
   describe Context do
     let(:url_generator) { |u| u }
-    subject { described_class.new(mock("Store"), mock("MessageBus"), url_generator) }
+    subject { described_class.new(mock("Store"), mock("MessageBus"), mock("application_id"), url_generator) }
     it_behaves_like('core context', :plate, :plates, Plate)
 
     context "#model" do
@@ -53,7 +53,8 @@ module Lims::Api
           Lims::Core::Persistence::Store.new
         }
         let(:message_bus) { mock(:message_bus).tap { |m| m.stub(:publish) { mock(:publish) }} }
-        subject { described_class.new(store, message_bus, url_generator) }
+        let(:application_id) { mock(:application_id) }
+        subject { described_class.new(store, message_bus, application_id, url_generator) }
         let(:uuid) { "hello, my name is UUID"}
         let(:uuid_resource) { Lims::Core::Persistence::UuidResource.new(:uuid => uuid, :model_class => Plate) }
 
@@ -67,7 +68,7 @@ module Lims::Api
     end
 
     context "#for_root" do
-      subject { described_class.new(mock(:store), mock(:message_bus), url_generator).for_root }
+      subject { described_class.new(mock(:store), mock(:message_bus), mock(:application_id), url_generator).for_root }
       it "is a resource" do
         subject.should be_a(Resource)
       end

--- a/spec/lims-api/core_action_resource_spec.rb
+++ b/spec/lims-api/core_action_resource_spec.rb
@@ -22,8 +22,9 @@ module Lims
           store.stub(:with_session).and_yield(mock(:session))
         end }
         let(:message_bus) { mock(:message_bus) }
+        let(:application_id) { mock(:application_id) }
         let(:server_context) {
-          Context.new(store, message_bus, lambda { |u| "/#{u}" }).tap do |context|
+          Context.new(store, message_bus, application_id, lambda { |u| "/#{u}" }).tap do |context|
             context.stub(:resource_class_for_class) { Lims::Api::CoreActionResource }
             context.stub(:publish) { mock(:publish) }
           end

--- a/spec/lims-api/core_resource_page_spec.rb
+++ b/spec/lims-api/core_resource_page_spec.rb
@@ -94,8 +94,9 @@ module Lims::Api
     context "within a valid context" do
       let(:store) { mock(:store) }
       let(:message_bus) { mock(:message_bus) }
+      let(:application_id) { mock(:application_id) }
       let(:server_context) {
-        Context.new(store, message_bus, lambda { |u| "/#{u}" })
+        Context.new(store, message_bus, application_id, lambda { |u| "/#{u}" })
       }
       let(:model_class) {
         class Model


### PR DESCRIPTION
To set the application_id in the published messages, a lims-app should setup the application_id when initializing lims-api in config.ru, passing an extra parameter to the ContextService with the name of the application (can be read from the gemspec file, name attribute).
